### PR TITLE
chore: bump sdk29

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@
 [![Build Status](https://travis-ci.org/apache/cordova-android.svg?branch=master)](https://travis-ci.org/apache/cordova-android)
 [![codecov.io](https://codecov.io/github/apache/cordova-android/coverage.svg?branch=master)](https://codecov.io/github/apache/cordova-android?branch=master)
 
+# Simplifield Cordova Android fork of 8.1.0
+We forked this repo in order to introduce a solution for work with storage on Android10+
+The latest v9 version that supports Android 10 sdk v29 - introduced many changes that brake some other plugins on sf-mobile.
+But without using sdk 29 we can't add a new policy introduced in Android 10.
+
+In cordova/android maximum sdk version is hardcoded. So even bumping in in config.xml won't work.
+So the first fix - update max sdk version from  28 to 29
+
+To use new storage a new option should be added to the manifest `android:requestLegacyExternalStorage="true"`
+Telerik/ImagePicker v2.3.6 introduce it. But in a runtime ImagePicker is failed due to manifest update errors
+Seems edit-config option for this storage update makes manifest file failed, so even updating to cordova/android v9 could fail.
+So here `android:requestLegacyExternalStorage="true"` is added manually. And now ImagePicker (and other plugins that require an access to the device storage) works fine on Android 10 and 11.
+
 # Cordova Android
 
 Cordova Android is an Android application library that allows for Cordova-based

--- a/bin/templates/project/AndroidManifest.xml
+++ b/bin/templates/project/AndroidManifest.xml
@@ -30,7 +30,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <application android:icon="@mipmap/ic_launcher" android:label="@string/app_name"
+    <application android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:requestLegacyExternalStorage="true" 
         android:hardwareAccelerated="true" android:supportsRtl="true">
         <activity android:name="__ACTIVITY__"
                 android:label="@string/activity_name"

--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -42,8 +42,8 @@ allprojects {
     project.ext {
       defaultBuildToolsVersion="28.0.3" //String
       defaultMinSdkVersion=19 //Integer - Minimum requirement is Android 4.4
-      defaultTargetSdkVersion=28 //Integer - We ALWAYS target the latest by default
-      defaultCompileSdkVersion=28 //Integer - We ALWAYS compile with the latest by default
+      defaultTargetSdkVersion=29 //Integer - We ALWAYS target the latest by default
+      defaultCompileSdkVersion=29 //Integer - We ALWAYS compile with the latest by default
     }
 }
 


### PR DESCRIPTION
To make ImagePicker work on Android10+ we need a custom fork of the cordova/android.

### Platforms affected
Android

### Motivation and Context
See Readme update

### Description
Added `android:requestLegacyExternalStorage="true"` to the manifest
Update sdk version in a `build.gradle`


### Testing
QAed on this app
https://github.com/SimpliField/sf-mobile/pull/1998

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
